### PR TITLE
Fix CSRF Token Error in Logout Button

### DIFF
--- a/frappe_geo_restrictions/templates/blocked-user/index.html
+++ b/frappe_geo_restrictions/templates/blocked-user/index.html
@@ -114,7 +114,7 @@
             document.getElementById("logout_button").addEventListener("click", function(event) {
                 event.preventDefault();
                 fetch("/api/method/logout", {
-                    method: "POST",
+                    method: "GET",
                     headers: {
                         "Content-Type": "application/json",
                     }

--- a/frappe_geo_restrictions/templates/blocked-user/index.html
+++ b/frappe_geo_restrictions/templates/blocked-user/index.html
@@ -114,9 +114,11 @@
             document.getElementById("logout_button").addEventListener("click", function(event) {
                 event.preventDefault();
                 fetch("/api/method/logout", {
-                    method: "GET",
+                    method: "POST",
                     headers: {
                         "Content-Type": "application/json",
+                        "X-Frappe-CSRF-Token": "{{csrf_token}}",
+                        "X-Frappe-Site-Name": window.location.hostname,
                     }
                 })
                 .then(response => response.json())

--- a/frappe_geo_restrictions/utils/__init__.py
+++ b/frappe_geo_restrictions/utils/__init__.py
@@ -262,25 +262,19 @@ def before_request():
 			if georestriction_no_access_template:
 				overriden_template = georestriction_no_access_template[0]
 
-		if overriden_template:
-			response = frappe.render_template(
-				overriden_template,
-				{
-					"title": title,
-					"description": description,
-					"status_code": status_code,
-					"is_logged_in": frappe.session.user != "Guest",
-				},
-			)
-			raise CustomGeoRestrictedError(Response(response, status=status_code, mimetype="text/html"))
+		template_path = overriden_template or "frappe_geo_restrictions/templates/blocked-user/index.html"
+
+		csrf_token = frappe.sessions.get_csrf_token()
+		frappe.db.commit()  # nosemgrep
 
 		response = frappe.render_template(
-			"frappe_geo_restrictions/templates/blocked-user/index.html",
+			template_path,
 			{
 				"title": title,
 				"description": description,
 				"status_code": status_code,
 				"is_logged_in": frappe.session.user != "Guest",
+				"csrf_token": csrf_token,
 			},
 		)
 		raise CustomGeoRestrictedError(Response(response, status=status_code, mimetype="text/html"))


### PR DESCRIPTION
This pull request improves the security and flexibility of the geo-restriction error handling in the app. The main changes include ensuring CSRF protection for blocked user pages and allowing for dynamic error templates.

Security improvements:

* Added the CSRF token (`csrf_token`) to the error template context and included it as an HTTP header in client-side POST requests to enhance CSRF protection. [[1]](diffhunk://#diff-0578e1caedbe196552366ff8adbaa519b93c1789a1c7ea21826de7b863168e3eL265-R277) [[2]](diffhunk://#diff-1405f83518cdd0c1cd49ab78233ba603112256567d2dc2fb603911f65e56109cR120-R121)

Template rendering flexibility:

* Refactored the error template rendering logic to support custom templates and ensured the correct template path is always used, falling back to the default if none is specified.